### PR TITLE
Clean up code and add oengus

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -699,6 +699,11 @@
         "key"
       ]
     },
+    "useOengusInsteadOfSrdc": {
+      "type": "boolean",
+      "description": "Looks up pronouns on Oengus instead of speedrun.com",
+      "default": false
+    },
     "discord": {
       "type": "object",
       "additionalProperties": false,
@@ -806,6 +811,7 @@
     "flagcarrier",
     "offsite",
     "server",
+    "useOengusInsteadOfSrdc",
     "discord",
     "streamlabsCharity",
     "therungg",

--- a/src/extension/misc.ts
+++ b/src/extension/misc.ts
@@ -185,7 +185,7 @@ export async function searchOengusPronouns(val: string): Promise<DonationReaderN
       `https://oengus.io/api/v1/users/${val}/search`,
       {
         headers: {
-          'User-Agent': 'github+bsgmarathon/esa-layouts',
+          'User-Agent': 'github+esamarathon/esa-layouts',
         },
       },
     );

--- a/src/extension/misc.ts
+++ b/src/extension/misc.ts
@@ -242,7 +242,7 @@ nodecg().listenFor('commentatorAdd', async (val: string | null | undefined, ack)
     await addNameToCommentators(val, commentatorsNew.value);
 
     // Update old commentators replicant.
-    commentators.value = commentatorsNew.value.map((it) => it.name);
+    commentators.value = commentatorsNew.value.map(objToSimpleDisplay);
   }
   if (ack && !ack.handled) {
     ack(null);

--- a/src/extension/mixer.ts
+++ b/src/extension/mixer.ts
@@ -6,6 +6,29 @@ import x32 from './util/x32';
 
 const config = nodecg().bundleConfig;
 
+function getSceneConfig() {
+  // These scenes will have the reader audible.
+  const readerScenes = [
+    obs.findScene(config.obs.names.scenes.commercials),
+    obs.findScene(config.obs.names.scenes.gameLayout),
+    obs.findScene(`${config.obs.names.scenes.gameLayout} (custom)`),
+    obs.findScene(config.obs.names.scenes.intermission),
+    obs.findScene(config.obs.names.scenes.intermissionCrowd),
+    obs.findScene(config.obs.names.scenes.readerIntroduction),
+  ].filter(Boolean) as string[];
+
+  // These scenes will have the game and players audible.
+  const gameScenes = [
+    obs.findScene(config.obs.names.scenes.gameLayout),
+    obs.findScene(`${config.obs.names.scenes.gameLayout} (custom)`),
+  ].filter(Boolean) as string[];
+
+  return {
+    readerScenes,
+    gameScenes,
+  };
+}
+
 function getNonGameScenes(): string[] {
   // These scenes will *not* have "LIVE Game/Mics" DCAs audible.
   return [
@@ -82,19 +105,8 @@ async function setInitialFaders(): Promise<void> {
     init = true;
     // On-Site
     if (!config.event.online) {
-      const readerScenes = [
-        obs.findScene(config.obs.names.scenes.commercials),
-        obs.findScene(config.obs.names.scenes.gameLayout),
-        obs.findScene(`${config.obs.names.scenes.gameLayout} (custom)`),
-        obs.findScene(config.obs.names.scenes.intermission),
-        obs.findScene(config.obs.names.scenes.intermissionCrowd),
-        obs.findScene(config.obs.names.scenes.readerIntroduction),
-      ].filter(Boolean) as string[];
-      // These scenes will have the game and players audible.
-      const gameScenes = [
-        obs.findScene(config.obs.names.scenes.gameLayout),
-        obs.findScene(`${config.obs.names.scenes.gameLayout} (custom)`),
-      ].filter(Boolean) as string[];
+      const { readerScenes, gameScenes } = getSceneConfig();
+
       if (readerScenes.includes(obs.currentScene || '')) {
         x32.setFader('/dca/2/fader', 0.75); // LIVE Readers
       } else {
@@ -122,20 +134,8 @@ obs.conn.on('TransitionBegin', async (data) => {
   if (config.x32.enabled) {
     // On-Site
     if (!config.event.online) {
-      // These scenes will have the reader audible.
-      const readerScenes = [
-        obs.findScene(config.obs.names.scenes.commercials),
-        obs.findScene(config.obs.names.scenes.gameLayout),
-        obs.findScene(`${config.obs.names.scenes.gameLayout} (custom)`),
-        obs.findScene(config.obs.names.scenes.intermission),
-        obs.findScene(config.obs.names.scenes.intermissionCrowd),
-        obs.findScene(config.obs.names.scenes.readerIntroduction),
-      ].filter(Boolean) as string[];
-      // These scenes will have the game and players audible.
-      const gameScenes = [
-        obs.findScene(config.obs.names.scenes.gameLayout),
-        obs.findScene(`${config.obs.names.scenes.gameLayout} (custom)`),
-      ].filter(Boolean) as string[];
+      const { readerScenes, gameScenes } = getSceneConfig();
+
       toggleFadeHelper('/dca/1/fader', gameScenes, data, false); // LIVE Runners
       toggleFadeHelper('/dca/2/fader', readerScenes, data, false); // LIVE Readers
       toggleFadeHelper('/dca/3/fader', gameScenes, data, false); // LIVE Games

--- a/src/types/schemas/configschema.d.ts
+++ b/src/types/schemas/configschema.d.ts
@@ -122,6 +122,10 @@ export interface Configschema {
 		address: string;
 		key: string;
 	};
+	/**
+	 * Looks up pronouns on Oengus instead of speedrun.com
+	 */
+	useOengusInsteadOfSrdc: boolean;
 	discord: {
 		enabled: boolean;
 		token: string;

--- a/src/types/schemas/index.d.ts
+++ b/src/types/schemas/index.d.ts
@@ -26,11 +26,11 @@ export * from './donationReader';
 // @ts-ignore
 export * from './donationReaderNew';
 // @ts-ignore
-export * from './donationsToRead';
-// @ts-ignore
 export * from './donationTotal';
 // @ts-ignore
 export * from './donationTotalMilestones';
+// @ts-ignore
+export * from './donationsToRead';
 // @ts-ignore
 export * from './gameLayouts';
 // @ts-ignore


### PR DESCRIPTION
Cleans up mixer code a bit to store the configuration in a single place.

Also adds oengus support (faster than srdc) and fixes srdc lookup for pronouns.

Will make a new PR later on to remove the old commentator and donation reader replicant as they are pretty much swappable in the layouts